### PR TITLE
Fix Snowflake ODBCInst

### DIFF
--- a/workflow/python/ds-pack/v1/README.md
+++ b/workflow/python/ds-pack/v1/README.md
@@ -29,6 +29,7 @@ psycopg2                      2.9.3
 snowflake                     0.0.3
 snowflake-connector-python    2.7.7
 sklearn                       0.0
+snowflake-sqlalchemy          1.3.2
 SQLAlchemy                    1.4.36
 ```
 

--- a/workflow/python/ds-pack/v1/requirements.txt
+++ b/workflow/python/ds-pack/v1/requirements.txt
@@ -5,3 +5,4 @@ snowflake==0.0.3
 snowflake-connector-python[pandas]==2.7.7
 sklearn==0.0
 SQLAlchemy==1.4.36
+snowflake-sqlalchemy==1.3.2

--- a/workflow/r/ds-pack/v1/Dockerfile
+++ b/workflow/r/ds-pack/v1/Dockerfile
@@ -1,7 +1,8 @@
 FROM r-base:4.2.0
 
 RUN apt-get update && \
-  apt-get install -y git unixodbc unixodbc-dev
+  apt-get install -y git unixodbc unixodbc-dev && \
+  ln -s /usr/lib/x86_64-linux-gnu/libodbcinst.so /usr/lib/x86_64-linux-gnu/libodbcinst.so.1
 
 # Install aws-cli
 RUN wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.5.zip -O awscliv2.zip \

--- a/workflow/r/standard-pack/v1/Dockerfile
+++ b/workflow/r/standard-pack/v1/Dockerfile
@@ -1,7 +1,8 @@
 FROM r-base:4.2.0
 
 RUN apt-get update && \
-  apt-get install -y git unixodbc unixodbc-dev
+  apt-get install -y git unixodbc unixodbc-dev && \
+  ln -s /usr/lib/x86_64-linux-gnu/libodbcinst.so /usr/lib/x86_64-linux-gnu/libodbcinst.so.1
 
 # Install aws-cli
 RUN wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.5.zip -O awscliv2.zip \


### PR DESCRIPTION
## Description
With the current installation of `unixodbc`, `libodbcinst.so.1` isn't added which is used by `snowflake-odbc` by default. To fix this we have created a symlink for it.

This also adds `snowflake-sqlalchemy` to the `python-ds-pack` image.

## Review Checks
- [x] 📝 The commit message is clear and descriptive
- [x] 🔐 The Security Considerations section in the PR description is complete - **Please do not remove this**
- [ ] ✅ Tests for the changes have been added and run successfully including the new changes
- [x] 📄 Documentation has been added / updated (for bug fixes / features)


## Dependencies
None

**Does this PR introduce a breaking change?** 
- [ ] Yes
- [x] No

## Security Considerations
None

## Types of change
- [x] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 Adding or updating configuration files, development scripts etc.
- [ ] ♻️ Refactoring (no functional changes, no API changes)
- [ ] 🧹 Chore (removing redundant files, fixing typos, etc.)
- [ ] 📄 Documentation Update 
- [ ] ❓ Other (if none of the other choices apply)

## Testing
- Check that we are able to connect to snowflake using the image.