### PR TITLE
feat: FO-2103 | Fix linting issues with Dockerfile mentioned in Knowledge Base

### DIFF
--- a/knowledge-base/non-root-user.md
+++ b/knowledge-base/non-root-user.md
@@ -9,7 +9,7 @@ This is done by using the `PEAK_USER_ID` build argument with a fixed value.
    ENV PEAK_USER_ID=$PEAK_USER_ID
 
    # Add a new user, this must have the User ID of PEAK_USER_ID
-   RUN id peak-user || useradd -m -d /home/peak-user -u $PEAK_USER_ID peak-user
+   RUN id peak-user || useradd -l -m -d /home/peak-user -u $PEAK_USER_ID peak-user
 
    # Give the new user the permissions to the directory that it might need
    RUN chown -R peak-user:peak-user /home/peak-user
@@ -45,7 +45,7 @@ ARG PEAK_USER_ID
 ENV PEAK_USER_ID=$PEAK_USER_ID
 
 # Add a new user, this must have the User ID of PEAK_USER_ID
-RUN id peak-user || useradd -m -d /home/peak-user -u $PEAK_USER_ID peak-user
+RUN id peak-user || useradd -l -m -d /home/peak-user -u $PEAK_USER_ID peak-user
 
 # Give the new user the permissions to the directory that it might need
 RUN chown -R peak-user:peak-user /home/peak-user
@@ -58,7 +58,7 @@ WORKDIR /home/peak-user
 # ------------------------------------------------
 
 RUN apt-get update && \
-  apt install curl dnsutils unzip git jq libpq-dev python-dev build-essential -y 
+  apt-get install --no-install-recommends curl dnsutils unzip git jq libpq-dev python-dev build-essential -y 
 
 # Install AWS CLI
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.5.zip" -o "awscliv2.zip" \
@@ -68,7 +68,7 @@ RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.5.zip" 
 
 # Install all the required Python libraries
 COPY --chown=peak-user:peak-user requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # ------------------------------------------------
 # Set Permissions and make the user the default


### PR DESCRIPTION
## Description
This PR fixes the issues that [hadolint](https://hadolint.github.io/hadolint/) raises when we lint the Dockerfile/commands mentioned in the Knowledge Base.

## Review Checks
- [x] 📝 The commit message is clear and descriptive
- [x] 🔐 The Security Considerations section in the PR description is complete
- [x] ✅ Tests for the changes have been added and run successfully including the new changes
- [x] 📄 Documentation has been added/updated (for bug fixes/features)

## Dependencies
None

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- [ ] Yes
- [x] No

## Security Considerations
N/A

## Types of change
- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 Adding or updating configuration files, development scripts, etc.
- [ ] ♻️ Refactoring (no functional changes, no API changes)
- [ ] 🧹 Chore (removing redundant files, fixing typos, etc.)
- [x] 📄 Documentation Update 
- [ ] ❓ Other (if none of the other choices apply)

# Testing
- Check that the Dockerfile mentioned in the Knowledge base gets built successfully.

# Other information
N/A