### PR TITLE
fix: Prevent step failure when a command fails while testing images

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run docker build on changed images
         if: steps.changed-directories.outputs.any_changed == 'true'
-        shell: bash
+        shell: bash --noprofile --norc {0}
         run: |
           for directory in ${{ steps.changed-directories.outputs.all_changed_files }}; do
             tag=$(echo $directory | tr / -)
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run snyk scan on changed images
         if: steps.changed-directories.outputs.any_changed == 'true'
-        shell: bash
+        shell: bash --noprofile --norc {0}
         id: snyk-scans
         run: |
           npx snyk auth $SNYK_TOKEN


### PR DESCRIPTION
## Description
This PR adds back `bash --noprofile --norc {0}` to `shell` option in steps. This ensures that the step doesn't fail when one of the commands exits with code other than 0.

We need this here because we want to continue testing other images if building one of the image fails.

## Review Checks
- [x] 📝 The commit message is clear and descriptive
- [x] 🔐 The Security Considerations section in the PR description is complete - **Please do not remove this**
- [x] ✅ Tests for the changes have been added and run successfully including the new changes
- [x] 📄 Documentation has been added / updated (for bug fixes / features)


## Dependencies
None

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- [ ] Yes
- [x] No

## Security Considerations
None

## Types of change
- [x] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 Adding or updating configuration files, development scripts etc.
- [ ] ♻️ Refactoring (no functional changes, no api changes)
- [ ] 🧹 Chore (removing redunant files, fixing typos etc.)
- [ ] 📄 Documentation Update 
- [ ] ❓ Other (if none of the other choices apply)

# Testing
N/A

# Other information
N/A